### PR TITLE
fix: event definition typo and doc format detail

### DIFF
--- a/contracts/MarketPlace.sol
+++ b/contracts/MarketPlace.sol
@@ -485,7 +485,7 @@ contract MarketPlace is
         uint256 royaltyAmount,
         uint256 erc777Amount
     ) internal {
-        require(erc777Amount >= amount, "NotEnougERC777Funds");
+        require(erc777Amount >= amount, "NotEnoughERC777Funds");
         // pay ERC777
         if (royaltyReceiver != address(0)) {
             IERC20(token).safeTransfer(royaltyReceiver, royaltyAmount);

--- a/contracts/interfaces/IMarketPlace.sol
+++ b/contracts/interfaces/IMarketPlace.sol
@@ -74,7 +74,7 @@ interface IMarketPlace {
      * @dev The amount of CSB to send must be specified in the `msg.value`.
      * @param nftAddress The contract address of the NFT.
      * @param tokenId The token id of the NFT.
-     * @param user The owner of ask order, as well as the  owner of the NFT.
+     * @param user The owner of ask order, as well as the owner of the NFT.
      */
     function acceptAsk(address nftAddress, uint256 tokenId, address user) external payable;
 

--- a/test/MarketPlace.t.sol
+++ b/test/MarketPlace.t.sol
@@ -674,7 +674,7 @@ contract MarketPlaceTest is Test, EmitExpecter {
         vm.prank(alice);
         market.ask(address(nft), 1, address(mira), price, block.timestamp + 10);
 
-        vm.expectRevert(abi.encodePacked("NotEnougERC777Funds"));
+        vm.expectRevert(abi.encodePacked("NotEnoughERC777Funds"));
         vm.prank(bob);
         mira.send(address(market), price - 1, abi.encode(address(nft), 1, alice));
     }


### PR DESCRIPTION
1. NotEnougERC777Funds -> NotEnoughERC777Funds
2. remove redundant space in comments of acceptAsk